### PR TITLE
Fix option tooltip covering input elements in IE

### DIFF
--- a/app/assets/stylesheets/compendium/options.css.scss
+++ b/app/assets/stylesheets/compendium/options.css.scss
@@ -1,12 +1,22 @@
 .option
 {
-  .option-label
+  @mixin label-font
   {
-    margin: 0px 0px 0px 0px;
     font-family: "Arial";
     font-size: 14px;
     font-weight: bold;
     color: #575757;
+  }
+
+  .label
+  {
+    @include label-font;
+  }
+
+  .option-label
+  {
+    margin: 0px 0px 0px 0px;
+    @include label-font;
   }
 
   .option-note

--- a/app/classes/compendium/presenters/option.rb
+++ b/app/classes/compendium/presenters/option.rb
@@ -9,30 +9,29 @@ module Compendium::Presenters
     end
 
     def label(form)
-      label = case option.type.to_sym
-        when :boolean, :radio
-          name
-
-        else
-          form.label option.name, name
-      end
-
-      out = ActiveSupport::SafeBuffer.new
-      out << content_tag(:span, label, class: 'option-label')
-
       if option.note?
         key = option.note == true ? :"#{option.name}_note" : option.note
         note = t("options.#{key}", cascade: { offset: 2 })
-        title = t("options.#{option.name}_note_title", default: '', cascade: { offset: 2 })
-
-        if defined?(AccessibleTooltip)
-          return accessible_tooltip(:help, label: out, title: title) { note }
-        else
-          out << content_tag(:div, note, class: 'option-note')
-        end
       end
 
-      out
+      if option.note? && defined?(AccessibleTooltip)
+        title = t("options.#{option.name}_note_title", default: '', cascade: { offset: 2 })
+        tooltip = accessible_tooltip(:help, label: name, title: title) { note }
+        return form.label option.name, tooltip
+      else
+        label = case option.type.to_sym
+          when :boolean, :radio
+            name
+
+          else
+            form.label option.name, name
+        end
+
+        out = ActiveSupport::SafeBuffer.new
+        out << content_tag(:span, label, class: 'option-label')
+        out << content_tag(:div, note, class: 'option-note') if option.note?
+        out
+      end
     end
 
     def note


### PR DESCRIPTION
Before 
-------
In IE10: Hovering over an input element would bring up the tooltip. This prevents users from interacting with the element.

![hover_before](https://cloud.githubusercontent.com/assets/1771310/7574496/c1ad256e-f7fb-11e4-862e-d0321fb68ad7.gif)

After
------
Only hovering over the label or the question mark icon brings up the tooltip.
Tested in IE10, IE9, IE8, FireFox 37.0.2, Safari 8.0.6, Chrome 42.0.2311.135
![hover_after](https://cloud.githubusercontent.com/assets/1771310/7574565/3ce45ce8-f7fc-11e4-917e-7a7691594597.gif)

